### PR TITLE
Add entry for dart_lnurl library

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ _Integrate **lnurl** in projects and services_.
 * [lnurl-ruby](https://github.com/bumi/lnurl-ruby) &ndash; A gem that provides helpers to work with **lnurl** from Ruby.
 * [lnurl-rust](https://github.com/edouardparis/rust-lnurl) &ndash; Rust helpers for **lnurl**.
 * [lnurl.net](https://github.com/Horndev/lnurl.net) &ndash; Library for **lnurl** in C#. Provides lnurl-auth helpers.
+* [dart_lnurl](https://github.com/bottlepay/dart_lnurl) &ndash; Library for **lnurl** in Dart.
 
 
 Tools


### PR DESCRIPTION
Added an entry for dart_lnurl from https://github.com/bottlepay/dart_lnurl

Pub.dev link: https://pub.dev/packages/dart_lnurl