### PR TITLE
BlueWallet is now supporting LNURL fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ _Some wallets that support **lnurl**_.
 | ---:                                                     | :---:     | :---:    | :---  | :---: | :---:   |
 | [BLW](https://lightning-wallet.com/)                     | ☑️         | ☑️        | ☑️     | ☑️     | ☑️       |
 | [Blixt](https://github.com/hsjoberg/blixt-wallet)        |           | ☑️        | ☑️ 💬  | ☑️     | ☑️       |
-| [BlueWallet](https://bluewallet.io/)                     |           | ☑️        | ☑️     |       |         |
+| [BlueWallet](https://bluewallet.io/)                     | ☑️         | ☑️        | ☑️     |       |         |
 | [Breez](https://breez.technology/)                       | ☑️         | ☑️        |       |       | ☑️       |
 | [coinos](https://coinos.io/)                             |           | ☑️        | ☑️     | ☑️     | ☑️       |
 | [lnbits](https://lnbits.org/)                            | ☑️         | ☑️        | ☑️ 💬  |       |         |


### PR DESCRIPTION
see merge: https://github.com/BlueWallet/BlueWallet/pull/1993