### PR TITLE
LNURL Fallback support for ZEBEDEE Wallet

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ _Some wallets that support **lnurl**_.
 | [Zap-iOS](https://www.zaphq.io/)                         |           | ☑️        | ☑️     |       | ☑️       |
 | [Zap-Android](https://www.zaphq.io/)                     | ☑️         | ☑️        | ☑️     |       | ☑️       |
 | [Zeus](https://github.com/ZeusLN/zeus)                   | ☑️         | ☑️        | ☑️ 💬  |       |         |
-| [ZEBEDEE](https://zbd.gg)                                |           | ☑️        | ☑️ 💬  |       |         |
+| [ZEBEDEE](https://zbd.gg)                                | ☑️         | ☑️        | ☑️ 💬  |       |         |
 
 *¹=the **fallback scheme** is defined on the first page of the [LNURL specifications](https://github.com/btcontract/lnurl-rfc#fallback-scheme). It allows to embed an bech32-encoded LNURL string into a normal Web-URL so that for example a LNURL QR code can be opened on every smartphone as a fallback with a normal web browser (if a specialised wallet app is not installed yet). Every LNURL supporting wallet should be able to parse such Web-URLs for bech32-encoded LNURL strings - it easy to implement and just requires a handfull of additional lines of code.*
 


### PR DESCRIPTION
## Notes

We've added LNURL Fallback support on the latest ZEBEDEE Wallet release for both iOS and Android devices.

## Commits

* feature: LNURL Fallback support posted in latest ZEBEDEE Wallet release