### PR TITLE
lnurl-channel support added to Zeus

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ _Some wallets that support **lnurl**_.
 | [Zap-Android](https://www.zaphq.io/)                              | ☑️         | ☑️        | ☑️     |       | ☑️       |
 | [Zap-iOS](https://www.zaphq.io/)                                  |           | ☑️        | ☑️     |       | ☑️       |
 | [ZEBEDEE](https://zbd.gg) (and [bots](https://zebedee.io/bots/))  | ☑️         | ☑️        | ☑️ 💬  |       |         |
-| [Zeus](https://github.com/ZeusLN/zeus)                            | ☑️         | ☑️        | ☑️ 💬  |       |         |
+| [Zeus](https://github.com/ZeusLN/zeus)                            | ☑️         | ☑️        | ☑️ 💬  |       | ☑️       |
 
 
 Libraries


### PR DESCRIPTION
Out in v0.5.2 which drops today.