### PR TITLE
Add Zeus lnurl-auth support

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ _Some wallets that support **lnurl**_.
 | [Zap-Android](https://www.zaphq.io/)                              | ☑️         | ☑️        | ☑️     |       | ☑️       |
 | [Zap-iOS](https://www.zaphq.io/)                                  |           | ☑️        | ☑️     |       | ☑️       |
 | [ZEBEDEE](https://zbd.gg) (and [bots](https://zebedee.io/bots/))  | ☑️         | ☑️        | ☑️ 💬  |       |         |
-| [Zeus](https://github.com/ZeusLN/zeus)                            | ☑️         | ☑️        | ☑️ 💬  |       | ☑️     |
+| [Zeus](https://github.com/ZeusLN/zeus)                            | ☑️         | ☑️        | ☑️ 💬  | ☑️     | ☑️     |
 
 
 Libraries


### PR DESCRIPTION
It was implemented in https://github.com/ZeusLN/zeus/pull/500.