### PR TITLE
Add Spring Security inegration for lnurl-auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ _Integrate **lnurl** in projects and services_.
 * [lnurl-rust](https://github.com/edouardparis/rust-lnurl) &ndash; Rust helpers for **lnurl**.
 * [lnurl.net](https://github.com/Horndev/lnurl.net) &ndash; Library for **lnurl** in C#. Provides lnurl-auth helpers.
 * [dart_lnurl](https://github.com/bottlepay/dart_lnurl) &ndash; Library for **lnurl** in Dart.
+* [spring-lnurl](https://github.com/theborakompanioni/bitcoin-spring-boot-starter#spring-lnurl) &ndash; Spring Security integration for **lnurl-auth**
 
 
 Tools


### PR DESCRIPTION
Add `spring-lnurl` (https://github.com/theborakompanioni/bitcoin-spring-boot-starter#spring-lnurl) to section "Libraries".
See [readme](https://github.com/theborakompanioni/bitcoin-spring-boot-starter/tree/devel/incubator/spring-lnurl) and/or [example application](https://github.com/theborakompanioni/bitcoin-spring-boot-starter/tree/master/examples/incubator/lnurl-auth-example-application).